### PR TITLE
Speedup updates.sh by caching Pacman output

### DIFF
--- a/updates.sh
+++ b/updates.sh
@@ -26,12 +26,17 @@ done
 
 IFS=$'\n'
 
+pacman_cache=$(mktemp)
+trap "rm ${pacman_cache}" EXIT
+pacman -Sl haskell-core | tr '[:upper:]' '[:lower:]' >$pacman_cache
+
 for p in $(cblrepo list -d --no-repo)
 do
     name=$(echo $p | awk '{print $1;}')
     ver=$(echo $p | awk '{print $2;}')
     pkg_name=haskell-$(echo ${name} | tr '[:upper:]' '[:lower:]')
-    repo_ver_rel=$(pacman -Si "${pkg_name}" | awk '/Version/ {print $3;}' | head -n 1)
+    repo_ver_rel=$(awk "\$2 == \"${pkg_name}\" {print \$3;}" $pacman_cache | head -n 1)
+    [[ $repo_ver_rel ]] || echo error: ${pkg_name} not found in repository
     if [ "${ver}" != "${repo_ver_rel}" ]
     then
         case ${mode} in


### PR DESCRIPTION
After the patch `updates.sh` becomes an order of magnitude faster while remaining reasonably KISS. 

It also lets you flexibly ignore or not ignore specific `pacman` repositories.

A yet another order of magnitude speedup is possible by using `join` and functional bash-fu. it's self-contained - paste to bash to see it mimicking `update.sh -b`:

```
join -e ccc -j1 -a1 \
        <(cblrepo list -d --no-repo | awk '{print "haskell-" tolower($1) " " $1 " " $2}' | sort) \
        <(pacman -Sl haskell-core | awk '{print $2 " " $3}' |sort) \
    | awk '$3 != $4 {print}' \
    | cut -d ' ' -f2 \
    | xargs echo cblrepo add
```

Note that `join` is designed to only operate on sorted data and thus this approach avoids quadratic algorithms entirely.

But I'm not sure if it's KISS enough.
